### PR TITLE
Add Self Message event

### DIFF
--- a/n8n-nodes/nodes/WhatsAppWeb/WhatsAppWebTrigger.node.ts
+++ b/n8n-nodes/nodes/WhatsAppWeb/WhatsAppWebTrigger.node.ts
@@ -38,11 +38,16 @@ export class WhatsAppWebTrigger implements INodeType {
 				options: [
 					{
 						name: 'Message Received',
-						value: 'messageReceived',
+						value: 'message',
 						description: 'Triggered when a WhatsApp message is received',
+					},
+					{
+						name: 'Message Sent',
+						value: 'selfMessage',
+						description: 'Triggered when a WhatsApp message is sent by you',
 					}
 				],
-				default: 'messageReceived',
+				default: 'message',
 				required: true,
 				description: 'Event that this node listens to',
 			},
@@ -90,6 +95,10 @@ export class WhatsAppWebTrigger implements INodeType {
 
 	async webhook(this: IWebhookFunctions): Promise<IWebhookResponseData> {
 		const body = this.getBodyData() as any;
+
+		const eventType = this.getNodeParameter('event', 'message');
+		if (body.type !== eventType) return {};
+
 		if (!body.data.hasMedia || !body.data.media.saved) {
 			return { workflowData: [this.helpers.returnJsonArray(body)] };
 		}

--- a/whatsapp-server/src/repository/eventManager.ts
+++ b/whatsapp-server/src/repository/eventManager.ts
@@ -24,6 +24,16 @@ export class WebhookMessageEvent implements WebhookEvent {
     }
 }
 
+export class WebhookSelfMessageEvent implements WebhookEvent {
+    public type = "selfMessage";
+    public data: WhatsAppMessage;
+
+
+    constructor(data: WhatsAppMessage) {
+        this.data = data;
+    }
+}
+
 
 // Event handling, do not touch
 /**

--- a/whatsapp-server/src/whatsapp/whatsApp.ts
+++ b/whatsapp-server/src/whatsapp/whatsApp.ts
@@ -1,4 +1,4 @@
-import { Client, LocalAuth, Message, MessageContent, MessageSendOptions, WAState } from "whatsapp-web.js";
+import { Client, LocalAuth, Message, MessageContent, MessageSendOptions } from "whatsapp-web.js";
 import { config } from "../config/config";
 import { parseWhatsAppMessage as convertWhatsAppMessage, WhatsAppMessage } from "../model/message";
 import { MessagingCache } from "./messagingCache";
@@ -34,11 +34,6 @@ export class WhatsApp {
 
         this.client.on("message", this.handleMessage.bind(this));
         this.client.on("message_create", this.handleSelfMessage.bind(this));
-
-        // this.client.on("state_changed", (state: WAState) => console.log(state));
-        // this.client.on("auth_failure", (message: string) => console.log(message));
-        // this.client.on("loading_screen", (percent: number) => console.log(percent));
-        // this.client.on("disconnected", (reason: any) => console.log(reason));
     }
 
 


### PR DESCRIPTION
The new event allows users to have messages they send trigger the workflow, not just messages they receive.
To achieve that, a new 'selfMessage' event was added to the whatsapp-server and exposed in the node.